### PR TITLE
Remove test check

### DIFF
--- a/prTemplate.md
+++ b/prTemplate.md
@@ -8,7 +8,7 @@
 #### Quality checklist (for PR author to complete BEFORE code review):
 - [ ] I've checked there is appropriate unit test coverage.
 - [ ] I've updated documentation with any changes to procedures.
-- [ ] I've tested this cross browser for any visual changes.
+- [ ] This change passes all necessary tests (cross browser, automated or otherwise).
 - [ ] I've checked this work against the requirements of the Jira.
 - [ ] I am ready for this to be code reviewed, merged and tested.
 

--- a/prTemplate.md
+++ b/prTemplate.md
@@ -15,7 +15,6 @@
 #### Reviewer 1
 - [ ] I agree with the assumptions made in the quality checklist.
 - [ ] I’ve witnessed the work behaving as expected.
-- [ ] I’ve witnessed the tests running successfully.
 - [ ] I’ve checked for appropriate test coverage.
 - [ ] I’ve checked for coding anti-patterns.
 - [ ] I've checked this work against the requirements of the Jira.
@@ -25,7 +24,6 @@
 #### Reviewer 2
 - [ ] I agree with the assumptions made in the quality checklist.
 - [ ] I’ve witnessed the work behaving as expected.
-- [ ] I’ve witnessed the tests running successfully.
 - [ ] I’ve checked for appropriate test coverage.
 - [ ] I’ve checked for coding anti-patterns.
 - [ ] I've checked this work against the requirements of the Jira.

--- a/prTemplate.md
+++ b/prTemplate.md
@@ -8,8 +8,8 @@
 #### Quality checklist (for PR author to complete BEFORE code review):
 - [ ] I've checked there is appropriate unit test coverage.
 - [ ] I've updated documentation with any changes to procedures.
-- [ ] This change passes all necessary tests (cross browser, automated or otherwise).
 - [ ] I've checked this work against the requirements of the Jira.
+- [ ] This change passes all necessary tests (cross browser, automated or otherwise).
 - [ ] I am ready for this to be code reviewed, merged and tested.
 
 #### Reviewer 1


### PR DESCRIPTION
As the testing is completed automatically by the build agent I suggest we remove the onus on the reviewers to check testing is complete (as generally i'll just look for the green "able to merge" button) and make the owner responsible for checking this.