### PR TITLE
Remove 'How should developer review'

### DIFF
--- a/prTemplate.md
+++ b/prTemplate.md
@@ -1,7 +1,6 @@
 #### What are the links to relevant tickets?
 #### What does this PR do?
 #### What functional/unit tests does this PR have?
-#### How should a developer review this?
 #### Any background context you want to provide?
 #### Screenshots (if appropriate)
 ---


### PR DESCRIPTION
This field always has 'visually' or 'eyes' written in it.

We can put any information into 'background context' if needed. So, lets remove it!

- [ ] I like this
- [ ] I also like this
- [x] I like cake